### PR TITLE
Increase rsum size, remove seq_matches

### DIFF
--- a/c/librcksum/rcksum.h
+++ b/c/librcksum/rcksum.h
@@ -18,21 +18,23 @@
 
 #include <stdio.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 struct rcksum_state;
 
 typedef int zs_blockid;
+typedef uint32_t rsum_component_type;
 
 struct rsum {
-	unsigned short	a;
-	unsigned short	b;
+    rsum_component_type a;
+    rsum_component_type b;
 } __attribute__((packed));
 
+// MD4 size in bytes
 #define CHECKSUM_SIZE 16
 
 struct rcksum_state *rcksum_init(zs_blockid nblocks, size_t blocksize,
-                                 int rsum_butes, unsigned int checksum_bytes,
-                                 int require_consecutive_matches);
+                                 int rsum_butes, unsigned int checksum_bytes);
 void rcksum_end(struct rcksum_state* z);
 
 /* These transfer out the filename and handle of the file backing the data retrieved.

--- a/c/libzsync/zsyncfile.h
+++ b/c/libzsync/zsyncfile.h
@@ -62,9 +62,8 @@ int zsyncfile_read_stream_write_blocksums(
 /* Decide how many bytes from the rsum hash and checksum hash per block to keep for
  * a file with the given length and blocksize. Also decide on seq_matches.
  */
-void zsyncfile_compute_hash_lengths(
-        off_t len, size_t blocksize,
-        int *rsum_len, int *checksum_len, int *seq_matches);
+void zsyncfile_compute_hash_lengths(off_t len, size_t blocksize,
+        int *rsum_len, int *checksum_len);
 
 /* Create a zsync file in fout.
  *
@@ -76,9 +75,8 @@ void zsyncfile_compute_hash_lengths(
  *
  * Returns 0 on success.
  */
-int zsyncfile_write(
-        FILE *fout, FILE *tf,
-        int rsum_len, int checksum_len, int seq_matches,
+int zsyncfile_write(FILE *fout, FILE *tf,
+        int rsum_len, int checksum_len,
         int do_recompress, const char *zfname, char *gzopts,
         const char *fname, time_t mtime,
         char **url, int nurls,

--- a/c/make.c
+++ b/c/make.c
@@ -212,7 +212,7 @@ int main(int argc, char **argv) {
     char *outfname = NULL;
     FILE *fout;
     char *infname = NULL;
-    int rsum_len, checksum_len, seq_matches;
+    int rsum_len, checksum_len;
     int do_compress = 0;
     int do_recompress = -1;     // -1 means we decide for ourselves
     int do_exact = 0;
@@ -451,11 +451,11 @@ int main(int argc, char **argv) {
                 infname);
     }
 
-    zsyncfile_compute_hash_lengths(state->len, state->blocksize, &rsum_len, &checksum_len, &seq_matches);
+    zsyncfile_compute_hash_lengths(state->len, state->blocksize, &rsum_len, &checksum_len);
 
     zsyncfile_write(
         fout, tf,
-        rsum_len, checksum_len, seq_matches,
+        rsum_len, checksum_len,
         do_recompress, zfname, gzopts,
         fname, mtime,
         url, nurls,


### PR DESCRIPTION
We use zsync for huge files where very large block sizes make sense
(1 MB and above). For that use case the 2x16bit rolling hash runs
can easily produce conflicts (see below). Extending the size of the
rolling hash to 2x32bits addresses that problem.

Example of problematic case for 1MB block size:
  Whole block is filled with byte b:
  rsum.a = (uint16_t)(b * 1MB) = 0 for all b
  rsum.b = (uint16_t)(b * 1MB * (1MB + 1)/2) = 0 for all b

Increasing rsum.a and rsum.b to be uint32_t makes these common block
contents not produce conflicts with the expected block sizes.

seq_matches is dropped because we had previously discovered problems
with it, it was intended to solve a similar problem, but maintaining it
would have meant more work.