### PR TITLE
Another Windows compile pass

### DIFF
--- a/c/librcksum/hash.c
+++ b/c/librcksum/hash.c
@@ -32,6 +32,10 @@
 #include "rcksum.h"
 #include "internal.h"
 
+static inline int min_int(int a, int b) {
+    return a > b ? b : a;
+}
+
 /* rcksum_add_target_block(self, blockid, rsum, checksum)
  * Sets the stored hash values for the given blockid to the given values.
  */
@@ -152,7 +156,7 @@ int build_hash(struct rcksum_state *z) {
     /* Allocate bit-table based on rsum. Aim is for 1/(1<<BITHASHBITS) load
      * factor, so hash_vits shouls be hash_bits + BITHASHBITS if we have that
      * many bits available. */
-    hash_bits = min(hash_bits + BITHASHBITS, avail_bits);
+    hash_bits = min_int(hash_bits + BITHASHBITS, avail_bits);
     z->bithashmask = (1U << hash_bits) - 1;
     z->bithash = calloc(z->bithashmask + 1, 1);
     if (!z->bithash) {

--- a/c/libzsync/sha1.h
+++ b/c/libzsync/sha1.h
@@ -10,6 +10,7 @@
 #define _SHA1_H
 
 #include "config.h"
+#include "zsglobal.h"
 
 #ifdef HAVE_INTTYPES_H
 #include <inttypes.h>

--- a/c/libzsync/zmap.h
+++ b/c/libzsync/zmap.h
@@ -15,6 +15,8 @@
 
 #include "zsglobal.h"
 
+#include <string.h>
+
 struct gzblock {
   uint16_t inbitoffset;
   uint16_t outbyteoffset;

--- a/c/libzsync/zsync.h
+++ b/c/libzsync/zsync.h
@@ -12,7 +12,10 @@
  *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *   COPYING file for details.
  */
+
 #include <stdbool.h>
+#include <stdio.h>
+#include <time.h>
 
 struct zsync_state;
 

--- a/c/libzsync/zsyncfile.h
+++ b/c/libzsync/zsyncfile.h
@@ -13,8 +13,6 @@
  *   COPYING file for details.
  */
 
-#include "zsglobal.h"
-
 #include <stdio.h>
 #include <time.h>
 #include "sha1.h"

--- a/c/zsglobal.h
+++ b/c/zsglobal.h
@@ -22,10 +22,10 @@
 #  include "config.h"
 #endif
 
-#if defined(Q_OS_UNIX)
-# include <arpa/inet.h>
-#elif defined(Q_OS_WIN)
+#ifdef _WIN32
 # include <winsock2.h>
+#else
+# include <arpa/inet.h>
 #endif
 
 #if defined(__GNUC__) && defined (__OpenBSD__)
@@ -33,13 +33,5 @@
 #else
 #  define ZS_DECL_BOUNDED(x,y,z)
 #endif /* ZS_DECL_BOUNDED */
-
-static inline unsigned min(unsigned short a, unsigned short b) {
-    return a > b ? b : a;
-}
-
-static inline unsigned max(unsigned short a, unsigned short b) {
-    return a > b ? a : b;
-}
 
 #endif


### PR DESCRIPTION
* Q_OS_* makes no sense if Qt is not incleded
* gmtime_r isn't portable
* remove min/max from zsglobal.h - you don't we a unsigned short
  version of this symbol to be visible anywhere